### PR TITLE
Replace NavigationStack with custom navigation container

### DIFF
--- a/Funnel/Funnel/ContentView.swift
+++ b/Funnel/Funnel/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
         ZStack {
             GradientBackground()
 
-            CustomNavigationContainer(currentView: $navigationDestination) {
+            PushTransitionContainer(currentView: $navigationDestination) {
                 // Main recording view
                 NewRecordingView()
                     .overlay {

--- a/Funnel/Funnel/ContentView.swift
+++ b/Funnel/Funnel/ContentView.swift
@@ -5,34 +5,33 @@ struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @StateObject private var recordingManager = RecordingManager()
     @StateObject private var gradientManager = GradientBackgroundManager()
+    @State private var navigationDestination: NavigationDestination = .recording
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                // Global gradient background
-                GlobalGradientBackground()
-                    .environmentObject(gradientManager)
+        ZStack {
+            GradientBackground()
 
-                ZStack {
-                    // Main recording view
-                    NewRecordingView()
-
-                    // Processing overlay
-                    if recordingManager.isProcessing {
-                        ProcessingOverlay()
-                            .transition(.opacity.combined(with: .scale(scale: 0.9)))
+            CustomNavigationContainer(currentView: $navigationDestination) {
+                // Main recording view
+                NewRecordingView()
+                    .overlay {
+                        if recordingManager.isProcessing {
+                            ProcessingOverlay()
+                                .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                        }
                     }
-                }
-                .navigationDestination(item: $recordingManager.presentedRecording) { recording in
-                    SwipeableCardsView(recording: recording)
-                        .navigationBarBackButtonHidden(true)
-                        .environmentObject(gradientManager)
-                }
+                    .animation(.easeInOut(duration: 0.3), value: recordingManager.isProcessing)
             }
-            .animation(.easeInOut(duration: 0.3), value: recordingManager.isProcessing)
         }
         .environmentObject(recordingManager)
         .environmentObject(gradientManager)
+        .onChange(of: recordingManager.presentedRecording) { _, newValue in
+            if let recording = newValue {
+                navigationDestination = .cards(recording)
+            } else {
+                navigationDestination = .recording
+            }
+        }
     }
 }
 

--- a/Funnel/Funnel/Views/CustomNavigationContainer.swift
+++ b/Funnel/Funnel/Views/CustomNavigationContainer.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+// Custom navigation container that provides slide animations without NavigationStack
+struct CustomNavigationContainer<Content: View>: View {
+    @Binding var currentView: NavigationDestination
+    let content: Content
+
+    @State private var displayedView: NavigationDestination = .recording
+    @State private var nextView: NavigationDestination?
+    @State private var offset: CGFloat = 0
+    @State private var isAnimating = false
+
+    init(currentView: Binding<NavigationDestination>, @ViewBuilder content: () -> Content) {
+        _currentView = currentView
+        self.content = content()
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                // Current view
+                viewForDestination(displayedView)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .offset(x: offset)
+
+                // Next view (slides in during transition)
+                if let nextView = nextView {
+                    viewForDestination(nextView)
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .offset(x: offset + (displayedView == .recording ? geometry.size.width : -geometry.size.width))
+                }
+            }
+        }
+        .onChange(of: currentView) { _, newValue in
+            guard !isAnimating else { return }
+            isAnimating = true
+
+            // Set up the next view
+            nextView = newValue
+
+            // Animate the transition
+            withAnimation(.easeInOut(duration: 0.3)) {
+                if newValue == .recording {
+                    // Sliding back (right to left)
+                    offset = UIScreen.main.bounds.width
+                } else {
+                    // Sliding forward (left to right)
+                    offset = -UIScreen.main.bounds.width
+                }
+            }
+
+            // After animation completes, update the displayed view
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                displayedView = newValue
+                nextView = nil
+                offset = 0
+                isAnimating = false
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func viewForDestination(_ destination: NavigationDestination) -> some View {
+        switch destination {
+        case .recording:
+            content
+        case let .cards(recording):
+            SwipeableCardsView(recording: recording)
+        }
+    }
+}
+
+// Navigation destination enum
+enum NavigationDestination: Equatable {
+    case recording
+    case cards(Recording)
+
+    static func == (lhs: NavigationDestination, rhs: NavigationDestination) -> Bool {
+        switch (lhs, rhs) {
+        case (.recording, .recording):
+            return true
+        case let (.cards(lhsRecording), .cards(rhsRecording)):
+            return lhsRecording.id == rhsRecording.id
+        default:
+            return false
+        }
+    }
+}
+

--- a/Funnel/Funnel/Views/NewRecordingView.swift
+++ b/Funnel/Funnel/Views/NewRecordingView.swift
@@ -23,7 +23,6 @@ struct NewRecordingView: View {
                 RecordingsListView(recordings: recordings)
                     .padding(.horizontal, 15)
                     .padding(.top, 178) // Space for logo
-                    .padding(.bottom, 195) // Space for floating record button
             }
 
             VStack(spacing: 0) {
@@ -298,12 +297,17 @@ struct RecordingsListView: View {
                     .buttonStyle(PlainButtonStyle())
                 }
             }
+            .padding(.bottom, 195) // Add bottom padding to content so last item can scroll above record button
         }
+        .scrollIndicators(.hidden)
     }
 }
 
 #Preview {
-    NewRecordingView()
-        .funnelPreviewEnvironment()
-        .environmentObject(RecordingManager())
+    ZStack {
+        GradientBackground()
+        NewRecordingView()
+            .funnelPreviewEnvironment()
+            .environmentObject(RecordingManager())
+    }
 }

--- a/Funnel/Funnel/Views/PushTransitionContainer.swift
+++ b/Funnel/Funnel/Views/PushTransitionContainer.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-// Custom navigation container that provides slide animations without NavigationStack
-struct CustomNavigationContainer<Content: View>: View {
+// Navigation container that provides push/pop slide animations without NavigationStack
+struct PushTransitionContainer<Content: View>: View {
     @Binding var currentView: NavigationDestination
     let content: Content
 

--- a/FunnelAI.xcodeproj/project.pbxproj
+++ b/FunnelAI.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 70;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		5DBA9E872E089E64000F4006 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 5DBA9E862E089E64000F4006 /* SwiftUIIntrospect */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		0A9BC078DD4AC38F123687A2 /* FunnelAI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FunnelAI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -23,6 +27,17 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		49E8777E2E03892C00721933 /* Funnel */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (49E877A72E03892C00721933 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Funnel; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5DBA9E842E089E35000F4006 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5DBA9E872E089E64000F4006 /* SwiftUIIntrospect in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		30EF63C64EAF6A14571B0920 /* Products */ = {
@@ -49,6 +64,7 @@
 			buildConfigurationList = FCB18D299A4B72C484FECEBA /* Build configuration list for PBXNativeTarget "FunnelAI" */;
 			buildPhases = (
 				DACB6B35E162417B9E12F0EF /* Sources */,
+				5DBA9E842E089E35000F4006 /* Frameworks */,
 				C671E455E945581A2E307E36 /* Resources */,
 			);
 			buildRules = (
@@ -60,6 +76,7 @@
 			);
 			name = FunnelAI;
 			packageProductDependencies = (
+				5DBA9E862E089E64000F4006 /* SwiftUIIntrospect */,
 			);
 			productName = Funnel;
 			productReference = 0A9BC078DD4AC38F123687A2 /* FunnelAI.app */;
@@ -89,6 +106,9 @@
 			);
 			mainGroup = D9581316AE7A5E7CB95F6728;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				5DBA9E852E089E64000F4006 /* XCRemoteSwiftPackageReference "swiftui-introspect" */,
+			);
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -327,6 +347,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		5DBA9E852E089E64000F4006 /* XCRemoteSwiftPackageReference "swiftui-introspect" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/siteline/swiftui-introspect";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		5DBA9E862E089E64000F4006 /* SwiftUIIntrospect */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5DBA9E852E089E64000F4006 /* XCRemoteSwiftPackageReference "swiftui-introspect" */;
+			productName = SwiftUIIntrospect;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 907C3DDE5BB93C24658194DA /* Project object */;
 }

--- a/FunnelAI.xcodeproj/project.pbxproj
+++ b/FunnelAI.xcodeproj/project.pbxproj
@@ -6,10 +6,6 @@
 	objectVersion = 70;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		5DBA9E872E089E64000F4006 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 5DBA9E862E089E64000F4006 /* SwiftUIIntrospect */; };
-/* End PBXBuildFile section */
-
 /* Begin PBXFileReference section */
 		0A9BC078DD4AC38F123687A2 /* FunnelAI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FunnelAI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -33,7 +29,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5DBA9E872E089E64000F4006 /* SwiftUIIntrospect in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,7 +71,6 @@
 			);
 			name = FunnelAI;
 			packageProductDependencies = (
-				5DBA9E862E089E64000F4006 /* SwiftUIIntrospect */,
 			);
 			productName = Funnel;
 			productReference = 0A9BC078DD4AC38F123687A2 /* FunnelAI.app */;
@@ -107,7 +101,6 @@
 			mainGroup = D9581316AE7A5E7CB95F6728;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				5DBA9E852E089E64000F4006 /* XCRemoteSwiftPackageReference "swiftui-introspect" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -347,25 +340,6 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		5DBA9E852E089E64000F4006 /* XCRemoteSwiftPackageReference "swiftui-introspect" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/siteline/swiftui-introspect";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.3.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		5DBA9E862E089E64000F4006 /* SwiftUIIntrospect */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5DBA9E852E089E64000F4006 /* XCRemoteSwiftPackageReference "swiftui-introspect" */;
-			productName = SwiftUIIntrospect;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 907C3DDE5BB93C24658194DA /* Project object */;
 }

--- a/buildServer.json
+++ b/buildServer.json
@@ -12,8 +12,8 @@
 	"argv": [
 		"/opt/homebrew/bin/xcode-build-server"
 	],
-	"workspace": "/Users/joeldrotleff/code/joya/funnel/FunnelAI.xcodeproj/project.xcworkspace",
-	"build_root": "/Users/joeldrotleff/Library/Developer/Xcode/DerivedData/FunnelAI-ctowujwwlmekvoctfwcjccrtbinc",
+	"workspace": "/Users/joel/code/joya/funnel/FunnelAI.xcodeproj/project.xcworkspace",
+	"build_root": "/Users/joel/Library/Developer/Xcode/DerivedData/FunnelAI-hbauekiyomzrwncewipkuecmksrg",
 	"scheme": "FunnelAI",
 	"kind": "xcode"
 }


### PR DESCRIPTION
## Summary
- Replaced NavigationStack with a custom navigation container to fix janky transitions
- Created smooth push/pull slide animations that work properly with the global gradient background
- Removed SwiftUIIntrospect dependency as it's no longer needed

## Changes
- **New CustomNavigationContainer**: Manages navigation with proper slide animations where both views move simultaneously
- **Updated ContentView**: Uses the custom container instead of NavigationStack
- **Updated SwipeableCardsView**: Removed dismiss dependency, navigation now handled by state
- **Removed dependency**: SwiftUIIntrospect is no longer needed

## Why
The original NavigationStack was causing janky transitions when used with a global gradient background. The custom solution provides smooth, coordinated animations where the old view slides out while the new view slides in.

🤖 Generated with [Claude Code](https://claude.ai/code)